### PR TITLE
Add more metrics, refactor metrics

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 typer = "*"
 pygit2 = "*"
+radon = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2c8dd5e8683ec2f1ab0c1c89fc6c7d35ad738e2cbb82134ca6c59abb8650d7cf"
+            "sha256": "c1e9c3375abf314da59264a053d6993a5cce9700639b3cf19a40b51b1d2050c7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -73,6 +73,28 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.4"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.18.2"
+        },
+        "mando": {
+            "hashes": [
+                "sha256:4ce09faec7e5192ffc3c57830e26acba0fd6cd11e1ee81af0d4df0657463bd1c",
+                "sha256:79feb19dc0f097daa64a1243db578e7674909b75f88ac2220f1c065c10a0d960"
+            ],
+            "version": "==0.6.4"
+        },
         "pycparser": {
             "hashes": [
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
@@ -104,6 +126,22 @@
             "index": "pypi",
             "version": "==1.5.0"
         },
+        "radon": {
+            "hashes": [
+                "sha256:7afa65db14d759616ab68033e0e1caf1f624c97308dd256afa47518ecebddf6e",
+                "sha256:ad4c1b7a228cb4d33f7500e89326fd98d287938b96820e748ccdbd1a9bf91f0b"
+            ],
+            "index": "pypi",
+            "version": "==4.5.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
         "typer": {
             "hashes": [
                 "sha256:5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303",
@@ -131,10 +169,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"
+                "sha256:20d326de75d13be6290925a95c94a9f368aca2f71cb7b753a938a5ae20f34a37",
+                "sha256:c9601dc863779db2fb1bf18b345bbfa2bb868463123cde6a7eff44b59e4ef739"
             ],
             "index": "pypi",
-            "version": "==20.8b1"
+            "version": "==21.4b1"
         },
         "cfgv": {
             "hashes": [
@@ -176,11 +215,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:398cb92a7599da0b433c65301a1b62b9b1f4bb8248719b84736af6c0b22289d6",
-                "sha256:4537474817e0bbb8cea3e5b7504b7de6d44e3f169a90846cbc6adb0fc8294502"
+                "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e",
+                "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.3"
+            "version": "==2.2.4"
         },
         "iniconfig": {
             "hashes": [
@@ -463,11 +502,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:49ec4eb4c224c6f7dd81bb6d0a28a09ecae5894f4e593c89b0db0885f565a107",
-                "sha256:83f95875d382c7abafe06bd2a4cdd1b363e1bb77e02f155ebe8ac082a916b37c"
+                "sha256:09c61377ef072f43568207dc8e46ddeac6bcdcaf288d49011bda0e7f4d38c4a2",
+                "sha256:a935126db63128861987a7d5d30e23e8ec045a73840eeccb467c148514e29535"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4.3"
+            "version": "==20.4.4"
         }
     }
 }

--- a/pyrepositoryminer/main.py
+++ b/pyrepositoryminer/main.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Iterable
 
 from pygit2 import (
     GIT_SORT_REVERSE,
@@ -25,6 +26,20 @@ def clone(
     "Clone a repository to a path."
     clone_repository(url, path, bare=bare)
     echo(f"Cloned {url} to {path}")
+
+
+@app.command()
+def branch(path: Path, local: bool = True, remote: bool = True) -> None:
+    repo = Repository(path)
+    branches: Iterable[str] = tuple()
+    if local and remote:
+        branches = repo.branches
+    elif local and not remote:
+        branches = repo.branches.local
+    elif not local and remote:
+        branches = repo.branches.remote
+    for branch_name in branches:
+        echo(branch_name)
 
 
 @app.command()

--- a/pyrepositoryminer/main.py
+++ b/pyrepositoryminer/main.py
@@ -40,10 +40,9 @@ def walk_commits(
 def clone(
     url: str,
     path: Path,
-    bare: bool = True,
 ) -> None:
     "Clone a repository to a path."
-    clone_repository(url, path, bare=bare)
+    clone_repository(url, path, bare=True)
     echo(f"Cloned {url} to {path}")
 
 

--- a/pyrepositoryminer/main.py
+++ b/pyrepositoryminer/main.py
@@ -63,10 +63,14 @@ def complexity(path: Path, simplify_first_parent: bool = True) -> None:
     repo = Repository(path)
     for branch_name in repo.branches:
         for commit in walk_commits(repo, branch_name, simplify_first_parent):
-            visitor = ComplexityVisitor()
-            visitor.visitTree(VisitableTree(commit.tree))
-            for blob_id, max_complexity in visitor.result:
-                echo(f"{branch_name},{str(commit.id)},{blob_id},{max_complexity}")
+            for blob_id, max_complexity in (
+                ComplexityVisitor().visitTree(VisitableTree(commit.tree)).result
+            ):
+                echo(
+                    "{:s},{:s},{:s},{:d}".format(
+                        branch_name, str(commit.id), str(blob_id), max_complexity
+                    )
+                )
 
 
 @app.command()
@@ -85,9 +89,7 @@ def raw(path: Path, simplify_first_parent: bool = True) -> None:
     repo = Repository(path)
     for branch_name in repo.branches:
         for commit in walk_commits(repo, branch_name, simplify_first_parent):
-            visitor = RawVisitor()
-            visitor.visitTree(VisitableTree(commit.tree))
-            for result in visitor.result:
+            for result in RawVisitor().visitTree(VisitableTree(commit.tree)).result:
                 echo(
                     "{:s},{:s},{:d},{:d},{:d}".format(
                         branch_name,
@@ -105,13 +107,11 @@ def filecount(path: Path, simplify_first_parent: bool = True) -> None:
     repo = Repository(path)
     for branch_name in repo.branches:
         for commit in walk_commits(repo, branch_name, simplify_first_parent):
-            visitor = FilecountVisitor()
-            visitor.visitTree(VisitableTree(commit.tree))
             echo(
                 "{:s},{:s},{:d}".format(
                     branch_name,
                     str(commit.id),
-                    visitor.result,
+                    FilecountVisitor().visitTree(VisitableTree(commit.tree)).result,
                 )
             )
 
@@ -126,9 +126,13 @@ def remote_filecount(
             url, tmpdirname, checkout_branch=checkout_branch, bare=True
         )
         for commit in walk_commits(repo, repo.head.shorthand, simplify_first_parent):
-            visitor = FilecountVisitor()
-            visitor.visitTree(VisitableTree(commit.tree))
-            echo(f"{repo.head.shorthand},{commit.id},{visitor.result}")
+            echo(
+                "{:s},{:s},{:d}".format(
+                    repo.head.shorthand,
+                    str(commit.id),
+                    FilecountVisitor().visitTree(VisitableTree(commit.tree)).result,
+                )
+            )
 
 
 @app.command()
@@ -141,6 +145,10 @@ def remote_loc(
             url, tmpdirname, checkout_branch=checkout_branch, bare=True
         )
         for commit in walk_commits(repo, repo.head.shorthand, simplify_first_parent):
-            visitor = LocVisitor()
-            visitor.visitTree(VisitableTree(commit.tree))
-            echo(f"{repo.head.shorthand},{commit.id},{visitor.result}")
+            echo(
+                "{:s},{},{:d}".format(
+                    repo.head.shorthand,
+                    str(commit.id),
+                    LocVisitor().visitTree(VisitableTree(commit.tree)).result,
+                )
+            )

--- a/pyrepositoryminer/treevisitor.py
+++ b/pyrepositoryminer/treevisitor.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from ast import (
+    AST,
+    Break,
+    Continue,
+    ExceptHandler,
+    For,
+    If,
+    NodeVisitor,
+    Try,
+    While,
+    With,
+    parse,
+    withitem,
+)
 from typing import Any, List, Tuple
 
 from pygit2 import Blob, Oid, Tree
@@ -8,6 +22,54 @@ from radon.complexity import cc_visit
 from radon.raw import Module, analyze
 
 from .visitableobject import VisitableBlob, VisitableTree
+
+
+class NestingASTVisitor(NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.n: int = 0
+        self.max_n: int = self.n
+
+    def visit(self, node: AST) -> NestingASTVisitor:
+        self.max_n = max(self.max_n, self.n)
+        super().visit(node)
+        return self
+
+    def nesting_visit(self, node: AST) -> None:
+        self.n += 1
+        super().generic_visit(node)
+        self.n -= 1
+
+    def visit_If(self, node: If) -> None:
+        return self.nesting_visit(node)
+
+    def visit_For(self, node: For) -> None:
+        return self.nesting_visit(node)
+
+    def visit_While(self, node: While) -> None:
+        return self.nesting_visit(node)
+
+    def visit_Break(self, node: Break) -> None:
+        return self.nesting_visit(node)
+
+    def visit_Continue(self, node: Continue) -> None:
+        return self.nesting_visit(node)
+
+    def visit_Try(self, node: Try) -> None:
+        return self.nesting_visit(node)
+
+    def visit_ExceptHandler(self, node: ExceptHandler) -> None:
+        return self.nesting_visit(node)
+
+    def visit_With(self, node: With) -> None:
+        return self.nesting_visit(node)
+
+    def visit_withitem(self, node: withitem) -> None:
+        return self.nesting_visit(node)
+
+    @property
+    def result(self) -> int:
+        return self.max_n
 
 
 class TreeVisitor(ABC):
@@ -79,14 +141,30 @@ class ComplexityVisitor(TreeVisitor):
 class RawVisitor(TreeVisitor):
     def __init__(self) -> None:
         super().__init__()
-        self.metrics: List[Module] = []
+        self.metrics: List[Tuple[Oid, Module]] = []
 
     def visitBlob(self, blob: VisitableBlob) -> RawVisitor:
         if blob.obj.name.endswith(".py"):
             data: Module = analyze(blob.obj.data.decode())
-            self.metrics.append(data)
+            self.metrics.append((blob.obj.id, data))
         return self
 
     @property
-    def result(self) -> List[Module]:
+    def result(self) -> List[Tuple[Oid, Module]]:
+        return self.metrics
+
+
+class NestingVisitor(TreeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.metrics: List[Tuple[Oid, int]] = []
+
+    def visitBlob(self, blob: VisitableBlob) -> NestingVisitor:
+        if blob.obj.name.endswith(".py"):
+            m = parse(blob.obj.data)
+            self.metrics.append((blob.obj.id, NestingASTVisitor().visit(m).result))
+        return self
+
+    @property
+    def result(self) -> List[Tuple[Oid, int]]:
         return self.metrics

--- a/pyrepositoryminer/treevisitor.py
+++ b/pyrepositoryminer/treevisitor.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, List, Tuple
 
-from pygit2 import Blob, Tree
+from pygit2 import Blob, Oid, Tree
 from radon.complexity import cc_visit
 from radon.raw import Module, analyze
 
@@ -10,15 +12,16 @@ from .visitableobject import VisitableBlob, VisitableTree
 
 class TreeVisitor(ABC):
     @abstractmethod
-    def visitBlob(self, blob: VisitableBlob) -> None:
+    def visitBlob(self, blob: VisitableBlob) -> TreeVisitor:
         pass
 
-    def visitTree(self, tree: VisitableTree) -> None:
+    def visitTree(self, tree: VisitableTree) -> TreeVisitor:
         for obj in tree.obj:
             if isinstance(obj, Tree):
                 VisitableTree(obj).accept(self)
             elif isinstance(obj, Blob):
                 VisitableBlob(obj).accept(self)
+        return self
 
     @property
     @abstractmethod
@@ -31,9 +34,10 @@ class LocVisitor(TreeVisitor):
         super().__init__()
         self.n: int = 0
 
-    def visitBlob(self, blob: VisitableBlob) -> None:
+    def visitBlob(self, blob: VisitableBlob) -> LocVisitor:
         if not blob.obj.is_binary:
             self.n += len(blob.obj.data.split(b"\n"))
+        return self
 
     @property
     def result(self) -> int:
@@ -45,8 +49,9 @@ class FilecountVisitor(TreeVisitor):
         super().__init__()
         self.n: int = 0
 
-    def visitBlob(self, blob: VisitableBlob) -> None:
+    def visitBlob(self, blob: VisitableBlob) -> FilecountVisitor:
         self.n += 1
+        return self
 
     @property
     def result(self) -> int:
@@ -56,17 +61,18 @@ class FilecountVisitor(TreeVisitor):
 class ComplexityVisitor(TreeVisitor):
     def __init__(self) -> None:
         super().__init__()
-        self.complexities: List[Tuple[str, str]] = []
+        self.complexities: List[Tuple[Oid, str]] = []
 
-    def visitBlob(self, blob: VisitableBlob) -> None:
+    def visitBlob(self, blob: VisitableBlob) -> ComplexityVisitor:
         if blob.obj.name.endswith(".py"):
             if complexities := cc_visit(blob.obj.data):
                 self.complexities.append(
                     (blob.obj.id, max(obj.complexity for obj in complexities))
                 )
+        return self
 
     @property
-    def result(self) -> List[Tuple[str, str]]:
+    def result(self) -> List[Tuple[Oid, str]]:
         return self.complexities
 
 
@@ -75,10 +81,11 @@ class RawVisitor(TreeVisitor):
         super().__init__()
         self.metrics: List[Module] = []
 
-    def visitBlob(self, blob: VisitableBlob) -> None:
+    def visitBlob(self, blob: VisitableBlob) -> RawVisitor:
         if blob.obj.name.endswith(".py"):
             data: Module = analyze(blob.obj.data.decode())
             self.metrics.append(data)
+        return self
 
     @property
     def result(self) -> List[Module]:

--- a/pyrepositoryminer/treevisitor.py
+++ b/pyrepositoryminer/treevisitor.py
@@ -1,0 +1,51 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from pygit2 import Blob, Tree
+
+from .visitableobject import VisitableBlob, VisitableTree
+
+
+class TreeVisitor(ABC):
+    @abstractmethod
+    def visitBlob(self, blob: VisitableBlob) -> None:
+        pass
+
+    def visitTree(self, tree: VisitableTree) -> None:
+        for obj in tree.obj:
+            if isinstance(obj, Tree):
+                VisitableTree(obj).accept(self)
+            elif isinstance(obj, Blob):
+                VisitableBlob(obj).accept(self)
+
+    @property
+    @abstractmethod
+    def result(self) -> Any:
+        pass
+
+
+class LocVisitor(TreeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.n: int = 0
+
+    def visitBlob(self, blob: VisitableBlob) -> None:
+        if not blob.obj.is_binary:
+            self.n += len(blob.obj.data.split(b"\n"))
+
+    @property
+    def result(self) -> int:
+        return self.n
+
+
+class FilecountVisitor(TreeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.n: int = 0
+
+    def visitBlob(self, blob: VisitableBlob) -> None:
+        self.n += 1
+
+    @property
+    def result(self) -> int:
+        return self.n

--- a/pyrepositoryminer/treevisitor.py
+++ b/pyrepositoryminer/treevisitor.py
@@ -3,6 +3,7 @@ from typing import Any, List, Tuple
 
 from pygit2 import Blob, Tree
 from radon.complexity import cc_visit
+from radon.raw import Module, analyze
 
 from .visitableobject import VisitableBlob, VisitableTree
 
@@ -67,3 +68,18 @@ class ComplexityVisitor(TreeVisitor):
     @property
     def result(self) -> List[Tuple[str, str]]:
         return self.complexities
+
+
+class RawVisitor(TreeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.metrics: List[Module] = []
+
+    def visitBlob(self, blob: VisitableBlob) -> None:
+        if blob.obj.name.endswith(".py"):
+            data: Module = analyze(blob.obj.data.decode())
+            self.metrics.append(data)
+
+    @property
+    def result(self) -> List[Module]:
+        return self.metrics

--- a/pyrepositoryminer/treevisitor.py
+++ b/pyrepositoryminer/treevisitor.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, List, Tuple
 
 from pygit2 import Blob, Tree
+from radon.complexity import cc_visit
 
 from .visitableobject import VisitableBlob, VisitableTree
 
@@ -49,3 +50,20 @@ class FilecountVisitor(TreeVisitor):
     @property
     def result(self) -> int:
         return self.n
+
+
+class ComplexityVisitor(TreeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.complexities: List[Tuple[str, str]] = []
+
+    def visitBlob(self, blob: VisitableBlob) -> None:
+        if blob.obj.name.endswith(".py"):
+            if complexities := cc_visit(blob.obj.data):
+                self.complexities.append(
+                    (blob.obj.id, max(obj.complexity for obj in complexities))
+                )
+
+    @property
+    def result(self) -> List[Tuple[str, str]]:
+        return self.complexities

--- a/pyrepositoryminer/visitableobject.py
+++ b/pyrepositoryminer/visitableobject.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from pygit2 import Blob, Object, Tree
+
+if TYPE_CHECKING:
+    from .treevisitor import TreeVisitor
+
+
+class VisitableObject(ABC):
+    @abstractmethod
+    def __init__(self, obj: Object) -> None:
+        pass
+
+    @abstractmethod
+    def accept(self, treevisitor: "TreeVisitor") -> None:
+        pass
+
+
+class VisitableTree(VisitableObject):
+    def __init__(self, obj: Tree) -> None:
+        super().__init__(obj)
+        self.obj: Tree = obj
+
+    def accept(self, treevisitor: "TreeVisitor") -> None:
+        treevisitor.visitTree(self)
+
+
+class VisitableBlob(VisitableObject):
+    def __init__(self, obj: Blob) -> None:
+        super().__init__(obj)
+        self.obj: Blob = obj
+
+    def accept(self, treevisitor: "TreeVisitor") -> None:
+        treevisitor.visitBlob(self)

--- a/scripts/mount-ramdisk-macos.sh
+++ b/scripts/mount-ramdisk-macos.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env /bin/bash
+
+# Pass the number of bytes
+
+diskutil erasevolume HFS+ 'RAMDisk' `hdiutil attach -nobrowse -nomount ram://$1`

--- a/scripts/unmount-ramdisk-macos.sh
+++ b/scripts/unmount-ramdisk-macos.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env /bin/bash
+
+# Pass the ramdisk to detach, e.g. disk3
+
+hdiutil detach $1


### PR DESCRIPTION
Resolves #3, resolves #4, resolves #5, resolves #6 (for macOS) and resolves #8.

## Cyclomatic Complexity
We calculate it via [radon](https://github.com/rubik/radon) for Python files. It is accessible via the `complexity` command. The output includes the branch, commit id, blob id and maximum complexity in that blob. Example usage:

```bash
$ pyrepositoryminer complexity ~/testing-repos/Cockpit.git
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,c21309855b30badc7e6510bbb94bf3b03d4df4e5,3
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,64fba7588d4fe023b345c266f857d75aebae0e93,1
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,0441ae6a34f6f8dcff33798b3545287f561b1418,1
```

## True Lines of Code
[radon](https://github.com/rubik/radon) also offers so-called raw metrics for Python files. We provide the lines of code (_loc_), logical lines of code (_lloc_), and source lines of code (_sloc_) with the `raw` command. The output is similar to the complexity command above, except that it provides the three aforementioned metrics instead of the cyclomatic complexity. Example usage:

```bash
$ pyrepositoryminer raw ~/testing-repos/Cockpit.git
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,c21309855b30badc7e6510bbb94bf3b03d4df4e5,50,34,34
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,64fba7588d4fe023b345c266f857d75aebae0e93,26,10,20
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,0441ae6a34f6f8dcff33798b3545287f561b1418,6,2,2
```

## Tree walking
Instead of duplicating tree walking for each function, we now employ a [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern). New metrics subclass `TreeVisitor`, must implement `visitBlob` and `result`, and may implement `visitTree`.

https://github.com/fabianhe/pyrepositoryminer/blob/6da95e47eed0e8e8717b9d1bec25196b76f1f68d/pyrepositoryminer/treevisitor.py#L75

## Ramdisk creation

For convenience, we provide a script for ramdisk creation. Run `./scripts/mount-ramdisk-macos.sh A` where A is the size of the ramdisk to create a ramdisk in a macOS environment.

https://github.com/fabianhe/pyrepositoryminer/blob/6da95e47eed0e8e8717b9d1bec25196b76f1f68d/scripts/mount-ramdisk-macos.sh#L5

Similarly, `./scripts/unmount-ramdisk-macos.sh B` unmounts disk B.

https://github.com/fabianhe/pyrepositoryminer/blob/6da95e47eed0e8e8717b9d1bec25196b76f1f68d/scripts/unmount-ramdisk-macos.sh#L5

## Nesting Level

Finally, we add the nesting level metric on Python files with our own implementation.

https://github.com/fabianhe/pyrepositoryminer/blob/6da95e47eed0e8e8717b9d1bec25196b76f1f68d/pyrepositoryminer/treevisitor.py#L157

It is accessible with the `nesting` command. The output includes the branch, commit id, blob id. The nesting level we output is the maximum nesting level found in that particular blob. Example usage:

```bash
$ pyrepositoryminer nesting ~/testing-repos/Cockpit.git
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,c21309855b30badc7e6510bbb94bf3b03d4df4e5,2
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,64fba7588d4fe023b345c266f857d75aebae0e93,0
dev,d6ac423d9f97c7a3a334956127a81b83b76de4dc,0441ae6a34f6f8dcff33798b3545287f561b1418,0
```

## Other

There is no longer a `bare` option. All repositories are cloned bare by default.
For convenience, we add a `branch` command that shows all branches, or just the local or remote branches. Example usage:
```bash
$ pyrepositoryminer branch ~/testing-repos/Cockpit.git
dev
origin/B/Add_custom_job_scheduler
origin/B/add_different_job_managers
```